### PR TITLE
fix: gracefully handle unsupported think models

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ claude-direct --model qwen3:14b         # Uses adapter directly on port 4000
 | Environment variable | Default | Description |
 | --- | --- | --- |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server URL |
-| `THINK_MODELS` | (empty) | Comma-separated model names that get `think: true` injected |
+| `THINK_MODELS` | (empty) | Comma-separated model names that get `think: true` injected. Models not in this set never forward `think` to Ollama. |
 
 ---
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,14 +1,11 @@
-import json
+import asyncio
 import pytest
-from fastapi.testclient import TestClient
-from proxy import app, _openai_to_ollama, _ollama_to_openai
-
-client = TestClient(app)
+import httpx
+from proxy import health, _openai_to_ollama, _ollama_to_openai, _post_with_think_fallback
 
 def test_health():
-    response = client.get("/health")
-    assert response.status_code == 200
-    assert response.json()["status"] == "ok"
+    response = asyncio.run(health())
+    assert response["status"] == "ok"
 
 def test_openai_to_ollama_translation():
     body = {
@@ -34,3 +31,79 @@ def test_ollama_to_openai_translation():
     assert openai_resp["choices"][0]["message"]["content"] == "hello"
     assert openai_resp["choices"][0]["message"]["reasoning_content"] == "reasoning..."
     assert openai_resp["usage"]["total_tokens"] == 30
+
+
+def test_openai_to_ollama_strips_think_for_unsupported_model():
+    body = {
+        "model": "deepseek-coder-v2:16b",
+        "messages": [{"role": "user", "content": "hi"}],
+        "think": True
+    }
+    ollama_body = _openai_to_ollama(body)
+    assert "think" not in ollama_body
+
+
+class _FakeResponse:
+    def __init__(self, status_code, text="", json_data=None):
+        self.status_code = status_code
+        self.text = text
+        self._json_data = json_data or {}
+        self._request = httpx.Request("POST", "http://localhost:11434/api/chat")
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "status error",
+                request=self._request,
+                response=httpx.Response(self.status_code, request=self._request, text=self.text),
+            )
+
+
+class _FakeAsyncClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, json):
+        self.calls.append(json)
+        return self._responses.pop(0)
+
+
+def test_post_with_think_fallback_retries_without_think_on_unsupported_thinking():
+    fake_client = _FakeAsyncClient([
+        _FakeResponse(400, text='{"error":"model does not support thinking"}'),
+        _FakeResponse(
+            200,
+            json_data={
+                "message": {"role": "assistant", "content": "ok"},
+                "done": True,
+                "prompt_eval_count": 1,
+                "eval_count": 2,
+            },
+        ),
+    ])
+
+    response = asyncio.run(
+        _post_with_think_fallback(
+            fake_client,
+            "http://localhost:11434/api/chat",
+            {
+                "model": "glm-5:cloud",
+                "messages": [{"role": "user", "content": "hello"}],
+                "think": True,
+            },
+        )
+    )
+
+    assert response.status_code == 200
+    assert fake_client.calls[0]["think"] is True
+    assert "think" not in fake_client.calls[1]


### PR DESCRIPTION
## Summary
- gate think forwarding to models in THINK_MODELS only
- add one-shot fallback retry without think when Ollama returns "does not support thinking"
- add unit tests for think stripping and retry behavior; clarify THINK_MODELS docs

## Test Plan
- [x] .venv/bin/python -m pytest tests/ -q

Fixes #9