### PR TITLE
infra: add coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest httpx fastapi[testclient]
+          pip install pytest httpx fastapi[testclient] pytest-cov
       - name: Run tests
         run: |
           export PYTHONPATH=$PYTHONPATH:.
-          pytest tests/
+          pytest --cov=proxy --cov-report=term-missing tests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 fastapi>=0.111.0
 uvicorn[standard]>=0.29.0
 httpx>=0.27.0
+pytest-cov>=5.0.0
 
 # Optional: for running LiteLLM proxy alongside
 # litellm[proxy]>=1.40.0


### PR DESCRIPTION
## Summary
- add pytest-cov to requirements and CI install step
- run pytest with coverage reporting in CI output
- show line-level missing coverage in CI logs

## Test Plan
- [x] .venv/bin/python -m pytest --cov=proxy --cov-report=term-missing tests/ -q

Fixes #16