### PR TITLE
docs: add security advisory reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes       |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately before disclosing it publicly.
+
+### How to Report
+
+- **GitHub Security Advisory (preferred)**:
+  https://github.com/T72/claude-code-ollama-adapter/security/advisories/new
+
+### What to Include
+
+- Detailed description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact assessment
+- Any suggested mitigations (if known)
+
+### Response Timeline
+
+- Initial response: within 72 hours
+- Ongoing updates: as progress is made
+
+## Security Best Practices
+
+- Keep dependencies updated
+- Use strong authentication methods
+- Review code changes carefully
+- Monitor for suspicious activity
+
+## Security Updates
+
+Security updates will be announced in:
+
+- GitHub Security Advisories
+- Release notes
+- Project documentation
+
+Thank you for helping keep this project secure!


### PR DESCRIPTION
## Summary
- add SECURITY.md with GitHub Security Advisory intake link
- clarify supported versions and response timeline

## Test Plan
- [ ] Not run (docs only)

Fixes #12