### PR TITLE
docs: add changelog and release cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Cadence
+
+- Regular releases: monthly (minor/patch)
+- Hotfixes: as needed
+
+## [Unreleased]
+
+- No unreleased changes.
+
+## [0.4.4] - 2026-02-28
+
+### Added
+
+- Coverage reporting in CI.
+- Expanded test coverage for proxy translation paths.
+
+### Fixed
+
+- Graceful handling for unsupported `think` models.

--- a/proxy.py
+++ b/proxy.py
@@ -24,7 +24,8 @@ THINK_MODELS: set[str] = _DEFAULT_THINK_MODELS | {
 
 _ANTHROPIC_DROP_PARAMS = {'output_config', 'thinking', 'metadata', 'anthropic_version', 'betas'}
 
-app = FastAPI(title='Claude Code Ollama Adapter', version='0.4.4')
+VERSION = '0.4.4'
+app = FastAPI(title='Claude Code Ollama Adapter', version=VERSION)
 
 def _should_think(model: str, request_think: Optional[bool]) -> bool:
     if request_think is False:


### PR DESCRIPTION
## Summary
- add CHANGELOG.md using Keep a Changelog + SemVer
- document release cadence and initial 0.4.4 entry
- set explicit VERSION constant in proxy.py

## Test Plan
- [ ] Not run (docs/governance change)

Fixes #17