### PR TITLE
docs: clarify PostgreSQL requirement for secure mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ litellm --config litellm_config.yaml --port 4001
 Use `litellm_config.secure.example.yaml` for production or shared environments requiring authentication.
 
 - **Virtual key authentication** - requires `master_key` + `DATABASE_URL`
+- **PostgreSQL is required** (secure mode does not run without a PostgreSQL database)
 - **Spend tracking & rate limiting** - built-in LiteLLM features
 - **Use case**: Production deployments, team environments
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,7 +98,11 @@ Contains:
 - Observability and monitoring setup
 - Incident response notes (if applicable)
 
-Current files: None.
+Current files:
+
+| File | Description |
+|------|-------------|
+| `docs/operations/README.md` | Deployment and runtime requirements |
 
 Rule:
 Operational docs must be reproducible and environment-specific.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,13 @@
+# Operations
+
+## LiteLLM Secure Mode Requirements
+
+LiteLLM secure mode requires a PostgreSQL database. It will not run without a
+valid `DATABASE_URL`.
+
+Example:
+
+```
+export DATABASE_URL="postgresql://user:password@localhost:5432/litellm"
+litellm --config litellm_config.secure.example.yaml --port 4001
+```

--- a/litellm_config.secure.example.yaml
+++ b/litellm_config.secure.example.yaml
@@ -16,8 +16,7 @@
 #    - Can be set via this config OR environment variable LITELLM_MASTER_KEY
 #
 # 2. Set DATABASE_URL (required when using master_key):
-#    - PostgreSQL: postgresql://user:password@localhost:5432/litellm
-#    - SQLite: sqlite:///./litellm.db
+#    - PostgreSQL (required): postgresql://user:password@localhost:5432/litellm
 #    - Set via environment variable DATABASE_URL
 #
 # 3. Start LiteLLM with your database:


### PR DESCRIPTION
## Summary
- add operations doc noting PostgreSQL requirement for secure mode
- call out PostgreSQL requirement in README
- tighten secure config comments to state PostgreSQL is required

## Test Plan
- [ ] Not run (docs only)

Fixes #14