### PR TITLE
docs: document non-docker deployment targets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,7 @@ Current files:
 | File | Description |
 |------|-------------|
 | `docs/operations/README.md` | Deployment and runtime requirements |
+| `docs/operations/deployment-targets.md` | Non-Docker deployment options |
 
 Rule:
 Operational docs must be reproducible and environment-specific.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -11,3 +11,8 @@ Example:
 export DATABASE_URL="postgresql://user:password@localhost:5432/litellm"
 litellm --config litellm_config.secure.example.yaml --port 4001
 ```
+
+## Deployment Targets Beyond Docker
+
+See `docs/operations/deployment-targets.md` for non-Docker options and their
+tradeoffs.

--- a/docs/operations/deployment-targets.md
+++ b/docs/operations/deployment-targets.md
@@ -1,0 +1,57 @@
+# Deployment Targets (Beyond Docker)
+
+This guide documents non-Docker deployment options for the adapter.
+
+## Bare Metal (Python Service)
+
+Prerequisites:
+- Python 3.12+
+- `pip install -r requirements.txt`
+
+Pros:
+- Simple to debug
+- Lowest operational overhead
+
+Cons:
+- Manual process management
+- Requires host-level security hardening
+
+## Managed Cloud VM (AWS/GCP/Azure)
+
+Prerequisites:
+- VM with Python 3.12+
+- Ingress/Firewall rules for the service port
+
+Pros:
+- Standard infrastructure
+- Easier networking than serverless
+
+Cons:
+- You manage OS patching and scaling
+
+## Kubernetes
+
+Prerequisites:
+- Container image and K8s cluster
+- Service/Ingress configuration
+
+Pros:
+- Scales cleanly
+- Standardized deployment pipelines
+
+Cons:
+- Higher operational complexity
+
+## Serverless (Functions/Containers)
+
+Prerequisites:
+- Provider that supports long-running HTTP services
+- Cold start considerations
+
+Pros:
+- Pay-per-use
+- Minimal host management
+
+Cons:
+- Latency variability
+- Limits on request duration and concurrency


### PR DESCRIPTION
## Summary
- add operations doc for non-Docker deployment targets
- link from operations README and docs index

## Test Plan
- [ ] Not run (docs only)

Fixes #15